### PR TITLE
Added logic to handle if the Data directory already exists.

### DIFF
--- a/Copy-Data.ps1
+++ b/Copy-Data.ps1
@@ -1,2 +1,7 @@
 #This script will copy data from the Data folder to the desktop of the local machine.
-Copy-Item .\Data -Destination C:\Users\Luke\Desktop\Data -Recurse
+if (-Not(Test-Path -Path "C:\Users\Luke\Desktop\Data")) {
+    Copy-Item .\Data -Destination C:\Users\Luke\Desktop\Data -Recurse
+}
+else {
+    Get-Childitem -Path .\Data | Copy-Item -Destination "C:\Users\Luke\Desktop\Data" -Recurse
+}


### PR DESCRIPTION
## Why
Running the copy-item command when the directory already exists copies the Data directory in to the existing Data directory rather than just overwriting the files as desired.